### PR TITLE
[PR] upgrade `com.baomidou:mybatis-plus-boot-starter` from 3.5.3.1 to 3.5.8 and support JDK8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# IDEA
+.idea/
+
+# VS Code
+.vscode/
+
 # Compiled class file
 *.class
 

--- a/ape-common/ape-common-mybatisplus/pom.xml
+++ b/ape-common/ape-common-mybatisplus/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-boot-starter</artifactId>
-            <version>3.5.3.1</version> <!-- 支持 Java 8 的稳定版本 -->
+            <version>3.5.8</version> <!-- 支持 Java 8 的稳定版本 -->
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
1. add the `.idea` to .gitignore
2. upgrade `com.baomidou:mybatis-plus-boot-starter` from 3.5.3.1 to 3.5.8 and support JDK8